### PR TITLE
Add basic ride-hailing structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Collev Ride App
+
+Esta versão adapta o projeto original para servir como um aplicativo de solicitações de corridas estilo taxi/uber. As classes originais de coletas permanecem, mas foram adicionadas novas estruturas para ilustrar o novo fluxo de corridas.
+
+## Novas funcionalidades
+- **Corrida**: nova classe de modelo que representa uma viagem solicitada.
+- **CorridaStatus**: enum com os estados `SOLICITADA`, `ACEITA`, `CONCLUIDA` e `CANCELADA`.
+- **SolicitarCorridaActivity**: tela simples onde um passageiro pode iniciar uma corrida.
+- **AceitarCorridaActivity**: tela para o motorista aceitar a corrida.
+
+Estas implementações são um esboço inicial; mais integrações e telas seriam necessárias para uma solução completa.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,12 @@
             android:name=".ui.common.PerfilActivity"
             android:exported="true" />
         <activity
+            android:name=".ui.passageiro.SolicitarCorridaActivity"
+            android:exported="false" />
+        <activity
+            android:name=".ui.motorista.AceitarCorridaActivity"
+            android:exported="false" />
+        <activity
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation" />
         <activity

--- a/app/src/main/java/com/empreendapp/collev/model/Corrida.kt
+++ b/app/src/main/java/com/empreendapp/collev/model/Corrida.kt
@@ -1,0 +1,19 @@
+package com.empreendapp.collev.model
+
+import java.util.*
+
+/**
+ * Representa uma corrida solicitada no aplicativo de taxi.
+ */
+data class Corrida(
+    var id: String? = null,
+    var passageiro: String? = null,
+    var motorista: String? = null,
+    var origem: String? = null,
+    var destino: String? = null,
+    var status: String? = null,
+    var valor: Double? = null,
+    var dataSolicitacao: Date? = null,
+    var dataInicio: Date? = null,
+    var dataFim: Date? = null
+)

--- a/app/src/main/java/com/empreendapp/collev/ui/common/MainActivity.kt
+++ b/app/src/main/java/com/empreendapp/collev/ui/common/MainActivity.kt
@@ -37,6 +37,8 @@ class MainActivity : AppCompatActivity()  {
         setStatusBarBorderRadiusWhite(this)
         initFirebase()
         initViews()
+        // Abertura da funcionalidade de corridas (exemplo)
+        startActivity(android.content.Intent(this, com.empreendapp.collev.ui.passageiro.SolicitarCorridaActivity::class.java))
     }
 
     private fun initFirebase() {

--- a/app/src/main/java/com/empreendapp/collev/ui/motorista/AceitarCorridaActivity.kt
+++ b/app/src/main/java/com/empreendapp/collev/ui/motorista/AceitarCorridaActivity.kt
@@ -1,0 +1,15 @@
+package com.empreendapp.collev.ui.motorista
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.empreendapp.collev.R
+
+/**
+ * Activity simples para que o motorista visualize e aceite corridas.
+ */
+class AceitarCorridaActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_aceitar_corrida)
+    }
+}

--- a/app/src/main/java/com/empreendapp/collev/ui/passageiro/SolicitarCorridaActivity.kt
+++ b/app/src/main/java/com/empreendapp/collev/ui/passageiro/SolicitarCorridaActivity.kt
@@ -1,0 +1,15 @@
+package com.empreendapp.collev.ui.passageiro
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.empreendapp.collev.R
+
+/**
+ * Activity simples para solicitar uma corrida.
+ */
+class SolicitarCorridaActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_solicitar_corrida)
+    }
+}

--- a/app/src/main/java/com/empreendapp/collev/util/enums/CorridaStatus.kt
+++ b/app/src/main/java/com/empreendapp/collev/util/enums/CorridaStatus.kt
@@ -1,0 +1,13 @@
+package com.empreendapp.collev.util.enums
+
+/**
+ * Estados possíveis para uma corrida.
+ */
+class CorridaStatus {
+    companion object {
+        const val SOLICITADA = "solicitada"
+        const val ACEITA = "aceita"
+        const val CONCLUIDA = "concluida"
+        const val CANCELADA = "cancelada"
+    }
+}

--- a/app/src/main/res/layout/activity_aceitar_corrida.xml
+++ b/app/src/main/res/layout/activity_aceitar_corrida.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvAceitarCorrida"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Aceitar Corrida"
+        android:textSize="18sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_solicitar_corrida.xml
+++ b/app/src/main/res/layout/activity_solicitar_corrida.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvSolicitarCorrida"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Solicitar Corrida"
+        android:textSize="18sp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- introduce README with new ride app description
- create Corrida model and status enum
- add activities for passenger and driver
- hook sample launch from `MainActivity`
- register new activities in manifest
- add simple layouts for the new screens

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68565a9289508333b5f6f056e8614203